### PR TITLE
fix issue with url being truncated on android

### DIFF
--- a/android/src/main/java/com/lg2/eddystone/EddystoneModule.java
+++ b/android/src/main/java/com/lg2/eddystone/EddystoneModule.java
@@ -236,7 +236,7 @@ public class EddystoneModule extends ReactContextBaseJavaModule {
 
         // build the url from the frame's bytes
         String url = getURLScheme(serviceData[2]);
-        for (int i = 3; i < 17; i++) {
+        for (int i = 3; i < 17 + 3; i++) {
           if (serviceData.length <= i) {
             break;
           }


### PR DESCRIPTION
noticed that onURLFrame provides truncated url on Android