### PR TITLE
update to be compatible with gradle 7.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
   

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lg2/react-native-eddystone",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A simple Eddystone implementation in React Native for both iOS and Android.",
   "main": "src/index.js",
   "directories": {


### PR DESCRIPTION
```
* What went wrong:
A problem occurred evaluating project ':lg2_react-native-eddystone'.
> Could not find method compile() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

https://stackoverflow.com/a/66910991
<img width="674" alt="Screen Shot 2022-04-12 at 15 30 06" src="https://user-images.githubusercontent.com/23699825/163029600-262c25cf-3905-4f4e-9f10-112c6ed9d33a.png">
